### PR TITLE
Catch DirectoryNotFoundException, show error to user

### DIFF
--- a/EmulationManager/EmulationManager/EmulationManager.csproj
+++ b/EmulationManager/EmulationManager/EmulationManager.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Commands\FixRomStreamingCompatibilityCommand.cs" />
     <Compile Include="Commands\LoadRomsAndEmulatorsCommand.cs" />
     <Compile Include="Helpers\ConfigurationHelper.cs" />
+    <Compile Include="Helpers\DebugManager.cs" />
     <Compile Include="Helpers\IOHelper.cs" />
     <Compile Include="Helpers\SteamHelper.cs" />
     <Compile Include="Helpers\StringHelper.cs" />

--- a/EmulationManager/EmulationManager/Helpers/DebugManager.cs
+++ b/EmulationManager/EmulationManager/Helpers/DebugManager.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace EmulationManager.Helpers
+{
+    public static class DebugManager
+    {
+        public static MessageBoxResult ShowErrorDialog(string errorMessage, Exception exception)
+        {
+            return MessageBox.Show(errorMessage + Environment.NewLine + exception.Message, "ERROR", MessageBoxButton.OK, MessageBoxImage.Error, MessageBoxResult.OK);
+        }
+    }
+}

--- a/EmulationManager/EmulationManager/Helpers/DebugManager.cs
+++ b/EmulationManager/EmulationManager/Helpers/DebugManager.cs
@@ -9,9 +9,9 @@ namespace EmulationManager.Helpers
 {
     public static class DebugManager
     {
-        public static MessageBoxResult ShowErrorDialog(string errorMessage, Exception exception)
+        public static void ShowErrorDialog(string errorMessage, Exception exception)
         {
-            return MessageBox.Show(errorMessage + Environment.NewLine + exception.Message, "ERROR", MessageBoxButton.OK, MessageBoxImage.Error, MessageBoxResult.OK);
+            MessageBox.Show(errorMessage + Environment.NewLine + exception.Message, "ERROR", MessageBoxButton.OK, MessageBoxImage.Error, MessageBoxResult.OK);
         }
     }
 }

--- a/EmulationManager/EmulationManager/ViewModels/EmuManagerViewModel.cs
+++ b/EmulationManager/EmulationManager/ViewModels/EmuManagerViewModel.cs
@@ -99,6 +99,15 @@ namespace EmulationManager.ViewModels
                 RomModels = IOHelper.GetRomInformationFromDisk(EmuManagerModel.RomDirectory);
             });
 
+            if (EmulatorModels == null || RomModels == null)
+            {
+                // If either model is null, we probably have already shown an error to the user,
+                // since something screwed up. But we may want to explain that nothing has happened in terms
+                // of loading the emulators and roms.
+                // TODO: Show error alert.
+                return;
+            }
+
             EmuManagerModel.RomsLoadedCount = RomModels.Length.ToString();
             EmuManagerModel.EmulatorsLoadedCount = EmulatorModels.Length.ToString();
             EmuManagerModel.ConsolesWithRomsCount = RomModels.GroupBy(x => x.Console).ToList().Count.ToString();


### PR DESCRIPTION
If you click on "Load Roms/Emulators into GURU" with invalid rom/emulator paths, the program crashes. I set up a basic debug manager (right now it only shows the error message, but you could have it do more advance things later if you want) and put the hooks in to show the error.

Now it should not fail.
